### PR TITLE
Remove the Globus SDK Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OAuthenticator currently supports the following authentication services:
 - [CILogon](oauthenticator/cilogon.py)
 - [GitHub](#github-setup)
 - [GitLab](#gitlab-setup)
-- [Globus](#globus-setup)
+- [Globus](oauthenticator/globus.py)
 - [Google](#google-setup)
 - [MediaWiki](oauthenticator/mediawiki.py)
 - [Moodle](#moodle-setup)

--- a/globus-requirements.txt
+++ b/globus-requirements.txt
@@ -1,3 +1,0 @@
-# extra requirements for globus
--r ./requirements.txt
-globus_sdk[jwt]>=1.0.0,<2.0.0

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -57,7 +57,7 @@ class GlobusLogoutHandler(LogoutHandler):
                     user.name, ','.join(state['tokens'].keys())
                 )
             )
-            state['tokens'] = ''
+            state['tokens'] = {}
             await user.save_auth_state(state)
 
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -113,16 +113,6 @@ class GlobusOAuthenticator(OAuthenticator):
             'urn:globus:auth:scope:transfer.api.globus.org:all',
         ]
 
-    allow_refresh_tokens = Bool(
-        help="""Allow users to have Refresh Tokens. If Refresh Tokens are not
-        allowed, users must use regular Access Tokens which will expire after
-        a set time. Set to False for increased security, True for increased
-        convenience."""
-    ).tag(config=True)
-
-    def _allow_refresh_tokens_default(self):
-        return True
-
     globus_local_endpoint = Unicode(
         help="""If Jupyterhub is also a Globus
     endpoint, its endpoint id can be specified here."""

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -68,13 +68,9 @@ class GlobusOAuthenticator(OAuthenticator):
     login_service = 'Globus'
     logout_handler = GlobusLogoutHandler
 
-    @default("userinfo_url")
-    def _userinfo_url_default(self):
+    @default("userdata_url")
+    def _userdata_url_default(self):
         return "https://auth.globus.org/v2/oauth2/userinfo"
-
-    userinfo_url = Unicode(
-        help="Globus URL to fetch details on a user after successful authentication"
-    ).tag(config=True)
 
     @default("authorize_url")
     def _authorize_url_default(self):
@@ -87,7 +83,6 @@ class GlobusOAuthenticator(OAuthenticator):
     revocation_url = Unicode(
         help="Globus URL to revoke live tokens."
     ).tag(config=True)
-
 
     @default("token_url")
     def _token_url_default(self):
@@ -186,7 +181,7 @@ class GlobusOAuthenticator(OAuthenticator):
         # Fetch user info at Globus's oauth2/userinfo/ HTTP endpoint to get the username
         user_headers = self.get_default_headers()
         user_headers['Authorization'] = 'Bearer {}'.format(token_json['access_token'])
-        req = HTTPRequest(self.userinfo_url, method='GET', headers=user_headers)
+        req = HTTPRequest(self.userdata_url, method='GET', headers=user_headers)
         user_resp = await http_client.fetch(req)
         user_json = json.loads(user_resp.body.decode('utf8', 'replace'))
         # It's possible for identity provider domains to be namespaced

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -154,8 +154,6 @@ class GlobusOAuthenticator(OAuthenticator):
         """
         # Complete login and exchange the code for tokens.
         http_client = AsyncHTTPClient()
-        if not self.token_url:
-            raise ValueError("Please set the $OAUTH2_TOKEN_URL environment variable")
         params = dict(
             redirect_uri=self.get_callback_url(handler),
             code=handler.get_argument("code"),
@@ -248,20 +246,6 @@ class GlobusOAuthenticator(OAuthenticator):
                               body=urllib.parse.urlencode({'token': token}),
                               )
             await http_client.fetch(req)
-
-    def get_callback_url(self, handler=None):
-        """
-        Getting the configured callback url
-        """
-        if self.oauth_callback_url is None:
-            raise HTTPError(
-                500,
-                'No callback url provided. '
-                'Please configure by adding '
-                'c.GlobusOAuthenticator.oauth_callback_url '
-                'to the config',
-            )
-        return self.oauth_callback_url
 
     def logout_url(self, base_url):
         return url_path_join(base_url, 'logout')

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -96,7 +96,7 @@ class GlobusOAuthenticator(OAuthenticator):
     ).tag(config=True)
 
     def _identity_provider_default(self):
-        return os.getenv('IDENTITY_PROVIDER', 'globusid.org')
+        return os.getenv('IDENTITY_PROVIDER', '')
 
     exclude_tokens = List(
         help="""Exclude tokens from being passed into user environments

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -269,7 +269,7 @@ class OAuthenticator(Authenticator):
 
     @default("extra_authorize_params")
     def _extra_authorize_params(self):
-        return os.environ.get("OAUTH2_EXTRA_AUTHORIZE_PARAMS", "")
+        return os.environ.get("OAUTH2_EXTRA_AUTHORIZE_PARAMS", {})
 
     extra_authorize_params = Dict(
         config=True,

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -18,7 +18,7 @@ from jupyterhub.handlers import BaseHandler
 from jupyterhub.auth import Authenticator
 from jupyterhub.utils import url_path_join
 
-from traitlets import Unicode, Bool, List, default
+from traitlets import Unicode, Bool, List, Dict, default
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -72,6 +72,10 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
     def _OAUTH_USERINFO_URL(self):
         return self.authenticator.userdata_url
 
+    @property
+    def _OAUTH_EXTRA_AUTHORIZE_PARAMS(self):
+        return self.authenticator.extra_authorize_params
+
     def set_state_cookie(self, state):
         self.set_secure_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=True)
 
@@ -100,14 +104,16 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
 
     def get(self):
         redirect_uri = self.authenticator.get_callback_url(self)
+        extra_params = self.authenticator.extra_authorize_params.copy()
         self.log.info('OAuth redirect: %r', redirect_uri)
         state = self.get_state()
         self.set_state_cookie(state)
+        extra_params['state'] = state
         self.authorize_redirect(
             redirect_uri=redirect_uri,
             client_id=self.authenticator.client_id,
             scope=self.authenticator.scope,
-            extra_params={'state': state},
+            extra_params=extra_params,
             response_type='code',
         )
 
@@ -259,6 +265,16 @@ class OAuthenticator(Authenticator):
         See the OAuth documentation of your OAuth provider for options.
         For GitHub in particular, you can see github_scopes.md in this repo.
         """,
+    )
+
+    @default("extra_authorize_params")
+    def _extra_authorize_params(self):
+        return os.environ.get("OAUTH2_EXTRA_AUTHORIZE_PARAMS", "")
+
+    extra_authorize_params = Dict(
+        config=True,
+        help="""Extra GET params to send along with the initial OAuth request
+        to the OAuth provider.""",
     )
 
     login_service = 'override in subclass'

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -1,64 +1,122 @@
-from pytest import fixture, mark, raises
-from tornado import web, gen
+from io import BytesIO
+import json
+from base64 import b64decode
+from pytest import fixture, raises
+from tornado import web
+from tornado.httpclient import HTTPResponse
+
 from unittest.mock import Mock
 
-from globus_sdk import ConfidentialAppAuthClient
 
 from ..globus import GlobusOAuthenticator, GlobusLogoutHandler
 
-from .mocks import setup_oauth_mock, no_code_test, mock_handler
+from .mocks import setup_oauth_mock, mock_handler
 
 
 def user_model(username):
     """Return a user model"""
     return {
-        'login': username,
+        'preferred_username': username,
     }
 
 
-@fixture
-def mock_globus_sdk(monkeypatch):
-    """Mock the globus_sdk request for 'oauth2_exchange_code_for_tokens', and
-    mock some of the items within the returned 'Tokens' class. """
-
-    class Tokens:
-
-        by_resource_server = {
-            'transfer.api.globus.org': {'access_token': 'TRANSFER_TOKEN'},
-            'auth.globus.org': {'access_token': 'AUTH_TOKEN'}
-
-        }
-        id_token = {'preferred_username': 'wash@globusid.org'}
-
-        def decode_id_token(self, client):
-            return self.id_token
-
-    tokens = Tokens()
-    monkeypatch.setattr(
-        ConfidentialAppAuthClient,
-        'oauth2_exchange_code_for_tokens',
-        lambda self, code: tokens
-    )
-    return tokens
+def revoke_token_request_handler(request):
+    assert request.method == 'POST', request.method
+    auth_header = request.headers.get('Authorization')
+    if auth_header:
+        header = auth_header.split(None, 1)[1]
+        print(header)
+        print(b64decode(header))
+        resp = BytesIO(json.dumps({'active': False}).encode('utf8'))
+        return HTTPResponse(request=request, code=200, buffer=resp)
+    else:
+        return HTTPResponse(request=request, code=401)
 
 
 @fixture
-def globus_client(client):
-    setup_oauth_mock(
-        client,
-        host=['auth.globus.org'],
-        access_token_path='/v2/oauth2/token',
-        user_path='/userinfo',
-        token_type='bearer',
-    )
+def mock_globus_token_response():
+    return {
+        'access_token': 'de48bedc44b79937f7aa67',
+        'id_token': 'ClRha2UgbXkgbG92ZSwgdGFrZSBteSBsYW5kClRha2UgbWUgd2hlcmUgSS'
+                    'BjYW5ub3Qgc3RhbmQKSSBkb24ndCBjYXJlIGNhdXNlIEknbSBzdGlsbCBm'
+                    'cmVlCllvdSBjYW4ndCB0YWtlIHRoZSBza3kgZnJvbSBtZQpUYWtlIG1lIG'
+                    '91dCwgdG8gdGhlIGJsYWNrClRlbGwgJ2VtIEkgYWluJ3QgY29taW5nIGJh'
+                    'Y2sKQnVybiB0aGUgbGFuZCBhbmQgYm9pbCB0aGUgc2VhCllvdSBjYW4ndC'
+                    'B0YWtlIHRoZSBza3kgZnJvbSBtZQpUaGVyZSdzIG5vIHBsYWNlIEkgY2Fu'
+                    'IGJlClNpbmNlIEkgZm91bmQgc2VyZW5pdHkKWW91IGNhbid0IHRha2UgdG'
+                    'hlIHNreSBmcm9tIG1lCg==',
+        'expires_in': 172800,
+        'resource_server': 'auth.globus.org',
+        'token_type': 'Bearer',
+        'state': '5a5929fa3c0210042c2fbb455e1e39d0',
+        'other_tokens': [{
+            'access_token': 'fceb9836f9b6d1ae7d',
+            'expires_in': 172800,
+            'resource_server': 'transfer.api.globus.org',
+            'token_type': 'Bearer',
+            'state': '5a5929fa3c0210042c2fbb455e1e39d0',
+            'scope': 'urn:globus:auth:scope:transfer.api.globus.org:all'}],
+        'scope': 'profile openid'}
+
+
+@fixture
+def globus_tokens_by_resource_server(mock_globus_token_response):
+    token_attrs = ['expires_in', 'resource_server', 'scope',
+                   'token_type', 'refresh_token', 'access_token']
+    auth_token_dict = {attr_name: mock_globus_token_response.get(attr_name) for attr_name in
+                       token_attrs}
+    other_tokens = [{attr_name: token_dict.get(attr_name) for attr_name in token_attrs}
+                    for token_dict in mock_globus_token_response['other_tokens']]
+    tokens = other_tokens + [auth_token_dict]
+    return {token_dict['resource_server']: token_dict for token_dict in tokens}
+
+
+def set_extended_token_response(client, host, access_token_path, new_token_response):
+    """The default client fixture does a nice job of checking the access code
+    response while returning tokens in the oauth2 spec, but Globus returns
+    a bunch of other tokens, including an id_token. We want to make sure we
+    capture the full Globus token response. This will attach the dict
+    new_token_response to the built-in test response if it returns successfully"""
+    # Find the existing endpoint, function pair in client.hosts
+    url, func = next(filter(lambda host: host[0]==access_token_path,
+                            client.hosts[host]))
+    # Wrap the built-in token response with our custom response, but only if
+    # it returns successfully with an access token!
+    def custom_token_response(request):
+        response = func(request)
+        if response.get('access_token'):
+            # The original access_token is checked,
+            new_token_response['access_token'] = response['access_token']
+            return new_token_response
+        else:
+            return response
+
+    # Return all existing paths with the addition of our custom wrapped handler.
+    hosts = filter(lambda chost: chost[0] != access_token_path, client.hosts[host])
+    client.add_host(host, [(url, custom_token_response)] + list(hosts))
     return client
 
 
 @fixture
-def mock_globus_user(mock_globus_sdk):
+def globus_client(client, mock_globus_token_response):
+    setup_oauth_mock(
+        client,
+        host='auth.globus.org',
+        access_token_path='/v2/oauth2/token',
+        user_path='/v2/oauth2/userinfo',
+        token_type='bearer',
+        token_request_style='post',
+    )
+    set_extended_token_response(client, 'auth.globus.org', '/v2/oauth2/token',
+                                mock_globus_token_response)
+    return client
+
+
+@fixture
+def mock_globus_user(globus_tokens_by_resource_server):
     class User:
         name = 'Wash'
-        state = {'tokens': mock_globus_sdk.by_resource_server}
+        state = {'tokens': globus_tokens_by_resource_server}
 
         async def get_auth_state(self):
             return self.state
@@ -68,9 +126,9 @@ def mock_globus_user(mock_globus_sdk):
     return User()
 
 
-async def test_globus(globus_client, mock_globus_sdk):
+async def test_globus(globus_client):
     authenticator = GlobusOAuthenticator()
-    handler = globus_client.handler_for_user(user_model('wash'))
+    handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     data = await authenticator.authenticate(handler)
     assert data['name'] == 'wash'
     tokens = list(data['auth_state']['tokens'].keys())
@@ -85,69 +143,59 @@ async def test_globus_pre_spawn_start(mock_globus_user):
     assert 'GLOBUS_DATA' in spawner.environment
 
 
-async def test_allow_refresh_tokens(globus_client, mock_globus_sdk, monkeypatch):
+async def test_allow_refresh_tokens(globus_client, mock_globus_token_response):
+    """
+    Mock test setting GlobusOAuthenticator.allow_refresh_tokens = True
+    """
+    mock_globus_token_response['refresh_token'] = 'user_refresh_token'
+    set_extended_token_response(globus_client, 'auth.globus.org',
+                                '/v2/oauth2/token', mock_globus_token_response)
     authenticator = GlobusOAuthenticator()
-    # Sanity check, this field should be set to True
-    assert authenticator.allow_refresh_tokens is True
-    authenticator.allow_refresh_tokens = False
-    monkeypatch.setattr(
-        ConfidentialAppAuthClient,
-        'oauth2_start_flow',
-        Mock()
-    )
-    handler = globus_client.handler_for_user(user_model('wash'))
-    await authenticator.authenticate(handler)
-    ConfidentialAppAuthClient.oauth2_start_flow.assert_called_with(
-        authenticator.get_callback_url(None),
-        requested_scopes=' '.join(authenticator.scope),
-        refresh_tokens=False
-    )
+    handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
+    response = await authenticator.authenticate(handler)
+    transfer_tokens = response['auth_state']['tokens']['transfer.api.globus.org']
+    assert 'refresh_token' in transfer_tokens
 
 
-async def test_restricted_domain(globus_client, mock_globus_sdk):
-    mock_globus_sdk.id_token = {'preferred_username': 'wash@serenity.com'}
+async def test_restricted_domain(globus_client):
     authenticator = GlobusOAuthenticator()
     authenticator.identity_provider = 'alliance.gov'
-    handler = globus_client.handler_for_user(user_model('wash'))
+    handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     with raises(web.HTTPError) as exc:
         await authenticator.authenticate(handler)
     assert exc.value.status_code == 403
 
 
-async def test_namespaced_domain(globus_client, mock_globus_sdk):
-    mock_globus_sdk.id_token = {'preferred_username':
-                                'wash@legitshipping.com@serenity.com'}
+async def test_namespaced_domain(globus_client):
     authenticator = GlobusOAuthenticator()
     # Allow any idp
     authenticator.identity_provider = ''
-    handler = globus_client.handler_for_user(user_model('wash'))
+    um = user_model('wash@legitshipping.com@serenity.com')
+    handler = globus_client.handler_for_user(um)
     data = await authenticator.authenticate(handler)
     assert data['name'] == 'wash'
 
 
-async def test_token_exclusion(globus_client, mock_globus_sdk):
+async def test_token_exclusion(globus_client):
     authenticator = GlobusOAuthenticator()
     authenticator.exclude_tokens = [
         'transfer.api.globus.org',
         'auth.globus.org'
     ]
-    handler = globus_client.handler_for_user(user_model('wash'))
+    handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     data = await authenticator.authenticate(handler)
     assert data['name'] == 'wash'
     assert list(data['auth_state']['tokens'].keys()) == []
 
 
-def test_revoke_tokens(monkeypatch):
-    monkeypatch.setattr(
-        ConfidentialAppAuthClient,
-        'oauth2_revoke_token',
-        Mock()
-    )
+async def test_revoke_tokens(globus_client, mock_globus_user):
+    globus_client.add_host('auth.globus.org', [('/v2/oauth2/token/revoke',
+                                               revoke_token_request_handler)])
     authenticator = GlobusOAuthenticator()
     service = {'transfer.api.globus.org': {'access_token': 'foo',
                                            'refresh_token': 'bar'}}
-    authenticator.revoke_service_tokens(service)
-    assert ConfidentialAppAuthClient.oauth2_revoke_token.called
+    authenticator.current_user = mock_globus_user
+    await authenticator.revoke_service_tokens(service)
 
 
 async def test_custom_logout(monkeypatch, mock_globus_user):
@@ -155,11 +203,7 @@ async def test_custom_logout(monkeypatch, mock_globus_user):
     authenticator = GlobusOAuthenticator()
     logout_handler = mock_handler(GlobusLogoutHandler,
                                   authenticator=authenticator)
-    monkeypatch.setattr(
-        web.RequestHandler,
-        'redirect',
-        Mock()
-    )
+    monkeypatch.setattr(web.RequestHandler, 'redirect', Mock())
     logout_handler.clear_login_cookie = Mock()
     logout_handler.get_current_user = Mock(return_value=mock_globus_user)
     logout_handler._jupyterhub_user = mock_globus_user
@@ -177,26 +221,22 @@ async def test_custom_logout(monkeypatch, mock_globus_user):
     assert logout_handler.clear_login_cookie.called
 
 
-async def test_logout_revokes_tokens(monkeypatch, mock_globus_user):
-
+async def test_logout_revokes_tokens(globus_client, monkeypatch, mock_globus_user):
+    globus_client.add_host('auth.globus.org', [('/v2/oauth2/token/revoke',
+                                               revoke_token_request_handler)])
     authenticator = GlobusOAuthenticator()
-    logout_handler = mock_handler(GlobusLogoutHandler,
-                                  authenticator=authenticator)
-    monkeypatch.setattr(
-        web.RequestHandler,
-        'redirect',
-        Mock()
-    )
+    logout_handler = mock_handler(GlobusLogoutHandler, authenticator=authenticator)
+
+    # Setup
+    monkeypatch.setattr(web.RequestHandler, 'redirect', Mock())
     logout_handler.get_current_user = Mock(return_value=mock_globus_user)
     logout_handler._jupyterhub_user = mock_globus_user
     monkeypatch.setitem(logout_handler.settings, 'statsd', Mock())
     monkeypatch.setitem(logout_handler.settings, 'login_url', '')
 
     logout_handler.clear_login_cookie = Mock()
-    authenticator.revoke_service_tokens = Mock()
     authenticator.revoke_tokens_on_logout = True
 
     await logout_handler.get()
-    assert authenticator.revoke_service_tokens.called
     auth_state = await mock_globus_user.get_auth_state()
-    assert auth_state == {'tokens': ''}
+    assert auth_state == {'tokens': {}}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 -r ./requirements.txt
--r ./globus-requirements.txt
 codecov
 flake8
 pyjwt


### PR DESCRIPTION
These changes remove the Globus SDK in favor of a pure tornado implementation. The main advantage is admins can reduce their dependencies on [Zero to Jupyterhub](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/images/hub/requirements.txt#L11). However, I found some other things not related to this pr:
* Refresh tokens had broken at some point, and can no longer be requested. I fixed this below.
    * Previously this was enabled by default, I really really don't think we should allow this.
* Previous installation was locked down to Globus ID by default -- changed to be open to users from any IdP
* Token revocation didn't seem to work before when it was enabled, due to method call order. Something must have changed to break this. Token revocation on logout is typically disabled since single-user servers might still be using them at the time the users logs out.
* With the Globus SDK, we had an advantage of easily being able to crack open the JWT token for user information. The pure tornado implementation turned out to be easier to simply call the Globus /userinfo endpoint for the same info. 
* Upgraded their oauth2 module to allow for extra data -- this allows for two things: 
  * Requesting refresh tokens.
  * Passing extra args to Globus, which we can use for [Globus Sessions](https://docs.globus.org/api/auth/sessions/#client-initiated-authns)
  * An example of setting both: 
      * `c.LocalGlobusOAuthenticator.extra_authorize_params = {'access_type': 'offline', 'session_required_identities': 'a65e5bc6-ab8c-469a-9d1d-b33608da9ffb'}`
   * This won't actually work until after https://github.com/globusonline/globus-auth/issues/1805 so that we can directly supply the auth provider domain or uuid.


For good measure, I also tested using the current built-in Generic OAuthenticator. It _works_ for pure auth, but doesn't account for the extra tokens returned by Globus. It also doesn't return auth_state data in quite the same format, which would be incompatible with the current way we inject tokens into servers. It also doesn't handle token revocation, or restricting identity providers (The latter we could actually patch in at its current state, as their current implementation allows passing a function to determine the user's username). 

This includes all the changes I would propose, but for the real PR I'll break up the backwards incompatible changes into multiple PRs. 